### PR TITLE
Use custom emotes for components

### DIFF
--- a/emojis.json
+++ b/emojis.json
@@ -1,0 +1,6 @@
+{
+	"small_left": "<:white_triangle_left:914153066033451049>",
+	"small_right": "<:white_triangle_right:914153084467445760>",
+	"arrow_left": "<:white_arrow_left:914153107884232774>",
+	"arrow_right": "<:white_arrow_right:914153133972799489>"
+}

--- a/src/cmd/docs.ts
+++ b/src/cmd/docs.ts
@@ -449,14 +449,14 @@ export async function classRunner(
 	}
 	if(c.constructor.params.length > 1 && c.constructor.description) e.addField("Constructor", Strings.truncate(`${c.constructor.description}\n\n${c.constructor.params.map(p => `\`${p.name}\` - ${Array.isArray(p.type) ? p.type.join(" | ") : p.type}${p.nullable ? " - Nullable" : ""}${p.optional ? " - Optional" : ""}\n${p.description}\n`).join("\n")}`, 1000), false)
 	e.setFooter(`Class ${index + 1}/${keys.length}`);
-	com.addInteractionButton(ButtonStyle.Primary, encodeCustomID("class", "prev_class", c.name, null, ver, page, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("\u25c0\ufe0f"), "Class");
+	com.addInteractionButton(ButtonStyle.Primary, encodeCustomID("class", "prev_class", c.name, null, ver, page, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("<:white_triangle_left:914020367167791166>", "custom"), "Class");
 	if (components) {
 		com
-			.addInteractionButton(ButtonStyle.Primary, encodeCustomID("class", "prev", c.name, null, ver, page, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("\u2b05\ufe0f"), "Page")
-			.addInteractionButton(ButtonStyle.Primary, encodeCustomID("class", "next", c.name, null, ver, page, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("\u27a1\ufe0f"), "Page");
+			.addInteractionButton(ButtonStyle.Primary, encodeCustomID("class", "prev", c.name, null, ver, page, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("<:white_arrow_left:914023268992823366>", "custom"), "Page")
+			.addInteractionButton(ButtonStyle.Primary, encodeCustomID("class", "next", c.name, null, ver, page, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("<:white_arrow_right:914023268627939359>", "custom"), "Page");
 		e.setFooter(`Class ${index + 1}/${keys.length} | Page ${page}/${pages}`);
 	}
-	com.addInteractionButton(ButtonStyle.Primary, encodeCustomID("class", "next_class", c.name, null, ver, page, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("\u25b6\ufe0f"), "Class")
+	com.addInteractionButton(ButtonStyle.Primary, encodeCustomID("class", "next_class", c.name, null, ver, page, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("<:white_triangle_right:914020367444606987>", "custom"), "Class")
 
 	if (interaction.type === InteractionType.ApplicationCommand) return res.status(200).json({
 		type: InteractionResponseType.ChannelMessageWithSource,
@@ -535,8 +535,8 @@ export async function eventRunner(
 
 		if(events.length > 1) {
 			com
-				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("event", "prev", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("\u2b05\ufe0f"))
-				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("event", "next", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("\u27a1\ufe0f"));
+				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("event", "prev", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("<:white_arrow_left:914023268992823366>", "custom"))
+				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("event", "next", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("<:white_arrow_right:914023268627939359>", "custom"));
 			e.setFooter(`Event ${index + 1}/${events.length}`);
 		}
 
@@ -614,8 +614,8 @@ export async function propertyRunner(
 
 		if(properties.length > 1) {
 			com
-				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("property", "prev", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("\u2b05\ufe0f"))
-				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("property", "next", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("\u27a1\ufe0f"));
+				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("property", "prev", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("<:white_arrow_left:914023268992823366>", "custom"))
+				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("property", "next", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("<:white_arrow_right:914023268627939359>", "custom"));
 			e.setFooter(`Property ${index + 1}/${properties.length}`);
 		}
 
@@ -696,8 +696,8 @@ export async function methodRunner(
 
 		if(methods.length > 1) {
 			com
-				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("method", "prev", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("\u2b05\ufe0f"))
-				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("method", "next", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("\u27a1\ufe0f"));
+				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("method", "prev", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("<:white_arrow_left:914023268992823366>", "custom"))
+				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("method", "next", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("<:white_arrow_right:914023268627939359>", "custom"));
 			e.setFooter(`Method ${index + 1}/${methods.length}`);
 		}
 

--- a/src/cmd/docs.ts
+++ b/src/cmd/docs.ts
@@ -21,6 +21,7 @@ import { Strings } from "@uwu-codes/utils";
 import FuzzySearch from "fuzzy-search";
 import { MessageFlags, ButtonStyle, InteractionResponseType } from "discord-api-types/v9";
 import { APIApplicationCommandAutocompleteInteraction } from "../../node_modules/discord-api-types/payloads/v9/_interactions/autocomplete";
+import emojis from "../../emojis.json";
 
 export function truncateChoices(values: Array<APIApplicationCommandOptionChoice>, max: number) {
 	if (values.length < max) return values;
@@ -449,14 +450,14 @@ export async function classRunner(
 	}
 	if(c.constructor.params.length > 1 && c.constructor.description) e.addField("Constructor", Strings.truncate(`${c.constructor.description}\n\n${c.constructor.params.map(p => `\`${p.name}\` - ${Array.isArray(p.type) ? p.type.join(" | ") : p.type}${p.nullable ? " - Nullable" : ""}${p.optional ? " - Optional" : ""}\n${p.description}\n`).join("\n")}`, 1000), false)
 	e.setFooter(`Class ${index + 1}/${keys.length}`);
-	com.addInteractionButton(ButtonStyle.Primary, encodeCustomID("class", "prev_class", c.name, null, ver, page, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("<:white_triangle_left:914020367167791166>", "custom"), "Class");
+	com.addInteractionButton(ButtonStyle.Primary, encodeCustomID("class", "prev_class", c.name, null, ver, page, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial(emojis.small_left, "custom"), "Class");
 	if (components) {
 		com
-			.addInteractionButton(ButtonStyle.Primary, encodeCustomID("class", "prev", c.name, null, ver, page, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("<:white_arrow_left:914023268992823366>", "custom"), "Page")
-			.addInteractionButton(ButtonStyle.Primary, encodeCustomID("class", "next", c.name, null, ver, page, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("<:white_arrow_right:914023268627939359>", "custom"), "Page");
+			.addInteractionButton(ButtonStyle.Primary, encodeCustomID("class", "prev", c.name, null, ver, page, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial(emojis.arrow_left, "custom"), "Page")
+			.addInteractionButton(ButtonStyle.Primary, encodeCustomID("class", "next", c.name, null, ver, page, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial(emojis.arrow_right, "custom"), "Page");
 		e.setFooter(`Class ${index + 1}/${keys.length} | Page ${page}/${pages}`);
 	}
-	com.addInteractionButton(ButtonStyle.Primary, encodeCustomID("class", "next_class", c.name, null, ver, page, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("<:white_triangle_right:914020367444606987>", "custom"), "Class")
+	com.addInteractionButton(ButtonStyle.Primary, encodeCustomID("class", "next_class", c.name, null, ver, page, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial(emojis.small_right, "custom"), "Class")
 
 	if (interaction.type === InteractionType.ApplicationCommand) return res.status(200).json({
 		type: InteractionResponseType.ChannelMessageWithSource,
@@ -535,8 +536,8 @@ export async function eventRunner(
 
 		if(events.length > 1) {
 			com
-				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("event", "prev", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("<:white_arrow_left:914023268992823366>", "custom"))
-				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("event", "next", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("<:white_arrow_right:914023268627939359>", "custom"));
+				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("event", "prev", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial(emojis.arrow_left, "custom"))
+				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("event", "next", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial(emojis.arrow_right, "custom"));
 			e.setFooter(`Event ${index + 1}/${events.length}`);
 		}
 
@@ -614,8 +615,8 @@ export async function propertyRunner(
 
 		if(properties.length > 1) {
 			com
-				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("property", "prev", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("<:white_arrow_left:914023268992823366>", "custom"))
-				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("property", "next", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("<:white_arrow_right:914023268627939359>", "custom"));
+				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("property", "prev", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial(emojis.arrow_left, "custom"))
+				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("property", "next", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial(emojis.arrow_right, "custom"));
 			e.setFooter(`Property ${index + 1}/${properties.length}`);
 		}
 
@@ -696,8 +697,8 @@ export async function methodRunner(
 
 		if(methods.length > 1) {
 			com
-				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("method", "prev", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("<:white_arrow_left:914023268992823366>", "custom"))
-				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("method", "next", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial("<:white_arrow_right:914023268627939359>", "custom"));
+				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("method", "prev", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial(emojis.arrow_left, "custom"))
+				.addInteractionButton(ButtonStyle.Primary, encodeCustomID("method", "next", className, otherName, ver, index + 1, (interaction.user || interaction.member?.user)!.id, cmd || "docs"), false, ComponentHelper.emojiToPartial(emojis.arrow_right, "custom"));
 			e.setFooter(`Method ${index + 1}/${methods.length}`);
 		}
 


### PR DESCRIPTION
Emotes are modified versions of [Twemoji](https://github.com/twitter/twemoji)

*their stance on credit*:
> As an open source project, attribution is critical from a legal, practical and motivational perspective in our opinion. The graphics are licensed under the CC-BY 4.0 which has a pretty good guide on best practices for attribution.

> However, we consider the guide a bit onerous and as a project, will accept a mention in a project README or an 'About' section or footer on a website. In mobile applications, a common place would be in the Settings/About section (for example, see the mobile Twitter application Settings->About->Legal section). We would consider a mention in the HTML/JS source sufficient also.

Couldn't test this because you had private libraries in the npm like **bruh**